### PR TITLE
Update project name to 'F5 BIG-IP Cloud Failover'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ source_encoding = 'utf-8-sig'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Cloud Failover'
+project = u'F5 BIG-IP Cloud Failover'
 copyright = u'2018 F5 Networks Inc'
 author = u'F5 Networks'
 


### PR DESCRIPTION
Changed <meta name="product" content="Cloud Failover"/> to "F5 BIG-IP Cloud Failover". As per TECHDOCS-2516/PDI0209643